### PR TITLE
Dcu bizarre modal

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -99,6 +99,7 @@ bizarreEvent.addEventListener("change", (event) => {
     currentlySelected = event.target.value
     console.log(currentlySelected, "currentlySelected")
         displayAttractionCards(event.target.value);
+        bizarreButton.style.display = "block";
     }
     )
     

--- a/styles/main.css
+++ b/styles/main.css
@@ -187,6 +187,13 @@ body {
     justify-content: flex-end;
 }
 
+#moreBizarreDetails{
+    background-color: #164A41;
+    color: white;
+    margin: 2px;
+    display: none;
+}
+
 .addBizarreButton{
     background-color: #164A41;
     color: white;


### PR DESCRIPTION
# Description

Changed the more details button to be hidden until a selection is made for bizarre attractions.



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions

Fetch dcu-bizarre-modal branch, serve it locally, observe hidden button becoming visible in bizarre preview section.



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
